### PR TITLE
Update cloud-services-d5f36cc.md

### DIFF
--- a/docs/01_required_setup/cloud-services-d5f36cc.md
+++ b/docs/01_required_setup/cloud-services-d5f36cc.md
@@ -8,7 +8,7 @@
 
 Cloud service information is imported or created as follows:
 
--   Automatic import by SAP \(preferred option\)
+-   Automatic import by SAP \(preferred option, for SAP Ariba Cloud Integration Gateway refer to https://support.sap.com/en/alm/sap-cloud-alm/operations/expert-portal/setup-managed-services/setup-ariba.html\)
 
 -   Automatic creation by means of the service registration \(available for push-enabled cloud services\)
 


### PR DESCRIPTION
The preferred option does not apply to SAP Ariba Cloud Integration Gateway because it cannot be collected automatically from the System Landscape Information Service (SLIS)